### PR TITLE
Make the blog preview images clickable

### DIFF
--- a/app/sections/writing.tsx
+++ b/app/sections/writing.tsx
@@ -36,7 +36,9 @@ export default function Writing() {
                   alt=""
                   className="aspect-[16/9] w-full rounded-2xl bg-gray-100 object-cover sm:aspect-[2/1] lg:aspect-[3/2]"
                 />
-                <div className="absolute inset-0 rounded-2xl ring-1 ring-inset ring-gray-900/10" />
+                <a href={post.href}>
+                  <div className="absolute inset-0 rounded-2xl ring-1 ring-inset ring-gray-900/10" />
+                </a>
               </div>
               <div className="max-w-xl">
                 <div className="mt-8 flex items-center gap-x-4 text-xs">


### PR DESCRIPTION
Adds an `absolute inset-0` a tag to the image. Surprised tailwind templates didn't have this in there already.