### PR TITLE
Simple blog footer

### DIFF
--- a/src/app/writing/[id]/page.tsx
+++ b/src/app/writing/[id]/page.tsx
@@ -23,7 +23,7 @@ export default async function Post({ params }: { params: { id: string } }) {
   return (
     <Container>
       <ProseContainer>
-        <article className="mb-48">
+        <article className="mb-24 sm:mb-48">
           <header className="flex flex-col mt-6 lg:mt-24 space-y-6">
             <h1 className="text-4xl font-bold tracking-tight text-zinc-800 sm:text-5xl dark:text-zinc-100">
               {article.title}

--- a/src/app/writing/[id]/page.tsx
+++ b/src/app/writing/[id]/page.tsx
@@ -2,7 +2,7 @@ import { MDXRemote } from "next-mdx-remote/rsc";
 import { PrismaClient } from "@prisma/client";
 
 import PostMetadata from "../components/PostMetadata";
-import { Container, ProseContainer } from "@/components/layout";
+import { Container, ProseContainer, WritingFooter } from "@/components/layout";
 import ArticleMenu from "../components/ArticleMenu";
 
 export default async function Post({ params }: { params: { id: string } }) {
@@ -23,7 +23,7 @@ export default async function Post({ params }: { params: { id: string } }) {
   return (
     <Container>
       <ProseContainer>
-        <article>
+        <article className="mb-48">
           <header className="flex flex-col mt-6 lg:mt-24 space-y-6">
             <h1 className="text-4xl font-bold tracking-tight text-zinc-800 sm:text-5xl dark:text-zinc-100">
               {article.title}
@@ -57,6 +57,7 @@ export default async function Post({ params }: { params: { id: string } }) {
             </p>
           </div>
         </article>
+        <WritingFooter />
       </ProseContainer>
     </Container>
   );

--- a/src/app/writing/layout.tsx
+++ b/src/app/writing/layout.tsx
@@ -1,4 +1,4 @@
-import { Header, Footer } from "@/components/layout";
+import { Header } from "@/components/layout";
 
 export const dynamic = "force-dynamic";
 
@@ -6,10 +6,9 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex flex-col w-full min-h-screen">
       <Header />
-      <div className="relative flex w-full flex-col grow mb-16">
-        <main className="flex-auto">{children}</main>
+      <div className="relative flex w-full flex-col grow">
+        <main className="flex flex-col flex-auto">{children}</main>
       </div>
-      <Footer />
     </div>
   );
 }

--- a/src/app/writing/page.tsx
+++ b/src/app/writing/page.tsx
@@ -1,7 +1,7 @@
 import { PrismaClient, type Post } from "@prisma/client";
 
 import ArticleCard from "./components/ArticleCard";
-import { Container } from "@/components/layout";
+import { Container, WritingFooter } from "@/components/layout";
 
 export default async function Writing() {
   const prisma = new PrismaClient();
@@ -9,14 +9,19 @@ export default async function Writing() {
   const articles = await prisma.post.findMany();
 
   return (
-    <Container>
-      <div className="mt-4 sm:mt-8">
-        <div className="flex flex-col space-y-4 sm:space-y-16">
-          {articles.map((article: Post) => {
-            return <ArticleCard key={article.id} article={article} />;
-          })}
+    <div className="grow flex flex-col justify-between">
+      <Container>
+        <div className="mt-4 sm:mt-8">
+          <div className="flex flex-col space-y-4 sm:space-y-16">
+            {articles.map((article: Post) => {
+              return <ArticleCard key={article.id} article={article} />;
+            })}
+          </div>
         </div>
-      </div>
-    </Container>
+      </Container>
+      <Container>
+        <WritingFooter />
+      </Container>
+    </div>
   );
 }

--- a/src/components/layout/WritingFooter.tsx
+++ b/src/components/layout/WritingFooter.tsx
@@ -8,9 +8,11 @@ export default function Footer() {
   return (
     <footer className="bg-amber-50">
       <div className="border-t-2">
-        <div className="flex justify-between py-16 items-baseline">
-          <p className="leading-5 text-gray-500">&copy; 2024 Gareth MacLeod</p>
-          <div className="flex flex-col lg:flex-row gap-6 lg:gap-12">
+        <div className="flex flex-col lg:flex-row w-full lg:justify-between py-16 items-baseline gap-8">
+          <p className="text-xs lg:text-base leading-5 text-gray-500 mx-auto lg:mx-0">
+            &copy; 2024 Gareth MacLeod
+          </p>
+          <div className="flex lg:flex-row gap-6 lg:gap-12 order-first lg:order-last mx-auto lg:mx-0">
             {links.map((link, index) => (
               <a key={index} href={link.href}>
                 {link.text}

--- a/src/components/layout/WritingFooter.tsx
+++ b/src/components/layout/WritingFooter.tsx
@@ -1,0 +1,24 @@
+const links = [
+  { href: `/`, text: "About" },
+  { href: `/writing`, text: "Writing" },
+  { href: `/#contact`, text: "Work with me" },
+];
+
+export default function Footer() {
+  return (
+    <footer className="bg-amber-50">
+      <div className="border-t-2">
+        <div className="flex justify-between py-16 items-baseline">
+          <p className="leading-5 text-gray-500">&copy; 2024 Gareth MacLeod</p>
+          <div className="flex flex-col lg:flex-row gap-6 lg:gap-12">
+            {links.map((link, index) => (
+              <a key={index} href={link.href}>
+                {link.text}
+              </a>
+            ))}
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -1,4 +1,5 @@
 export { Container, ContainerInner, ContainerOuter } from "./Container";
 export { default as ProseContainer } from "./ProseContainer";
 export { default as Footer } from "./Footer";
+export { default as WritingFooter } from "./WritingFooter";
 export { default as Header } from "./Header";

--- a/src/data/writing.tsx
+++ b/src/data/writing.tsx
@@ -5,7 +5,7 @@ export const writing_data = [
     href: "/writing/4",
     description:
       "I did something hard once: I took my startup from zero to $1m in daily volume in 4 months. Something has bothered me ever since: it felt easy.",
-    imageUrl: "/covers/ease_post.webp",
+    imageUrl: "/covers/ease.png",
     date: "Feb 16, 2024",
     datetime: "2024-02-16",
   },


### PR DESCRIPTION
I was imagining something more elaborate but this will work well for a minimal design.

Todo
- [ ] mobile responsiveness testing
- [ ] I feel like some of this markup can be simplified, especially in the 'grow' category





Design
===
 
![Screenshot 2024-07-30 at 9 13 36 PM](https://github.com/user-attachments/assets/b5151c8e-a80c-4a48-9969-3d89663533e9)
![Screenshot 2024-07-30 at 9 13 54 PM](https://github.com/user-attachments/assets/1d3354d6-648c-423c-b949-f939e61758d1)
![Screenshot 2024-07-30 at 9 14 13 PM](https://github.com/user-attachments/assets/e6d84642-2e1f-4351-826c-1b4c55c59045)
