### PR TITLE
Add GitHub Pages static export and deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,43 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./out
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,10 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  output: 'export',
+  basePath: '/garethdmmcom',
+  images: {
+    unoptimized: true,
+  },
+};
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

- Configures Next.js for static export (`output: 'export'`) targeting `garethdmm.github.io/garethdmmcom/`
- Adds `basePath: '/garethdmmcom'` and `images: { unoptimized: true }` to `next.config.mjs`
- Adds `.github/workflows/deploy.yml` to build and deploy to GitHub Pages on every push to `main`

## Test plan

- [ ] Merge PR and confirm the Actions workflow runs successfully
- [ ] In GitHub repo **Settings → Pages**, set source to **"GitHub Actions"** (required before first deploy will succeed)
- [ ] Verify site is live at `https://garethdmm.github.io/garethdmmcom/`