### PR TITLE
Add Cloudflare Web Analytics

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,7 +13,14 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        {children}
+        <script
+          defer
+          src="https://static.cloudflareinsights.com/beacon.min.js"
+          data-cf-beacon='{"token": "7b0927d506dc414eab84439edc8a3c29"}'
+        />
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- Add Cloudflare Web Analytics beacon script to the site layout
- Privacy-friendly, cookie-free analytics for tracking visitors, referrers, and geography

## Test plan
- [ ] Deploy and verify analytics data appears in Cloudflare dashboard