### PR TITLE
Polish link underline interactions

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -17,11 +17,15 @@ body {
 
 a {
   color: #4a6fa5;
-  text-decoration: none;
+  text-decoration: underline;
+  text-decoration-color: transparent;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.18em;
+  transition: text-decoration-color 150ms ease;
 }
 
 a:hover {
-  text-decoration: underline;
+  text-decoration-color: currentColor;
 }
 
 hr {


### PR DESCRIPTION
## Summary

- Adds a thin, offset underline treatment to links.
- Fades the existing blue accent into view on hover.

## Why

The current browser-default underline appears abruptly and sits close to the text. This keeps the site's restrained visual style while making link interactions feel more deliberate.

## Impact

Cosmetic only: no content, layout, routing, or functional behaviour changes.

## Validation

- Verified the committed diff is limited to `app/globals.css`.
- Reviewed the branch version of the stylesheet.
- Automated checks were not run for this CSS-only change.
