### PR TITLE
Add a podcast feed for listen-later essays

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-Gareth's personal website circa 2026. Intended to be a small collection of works and offramps to other source like github.
+Gareth's personal website circa 2026. Intended to be a small collection of works and offramps to other sources like GitHub.
+
+Podcast publishing and directory setup is documented in
+[`docs/podcast-setup.md`](docs/podcast-setup.md).

--- a/app/blog/how-to-feel-when-your-startup-feels-easy/page.tsx
+++ b/app/blog/how-to-feel-when-your-startup-feels-easy/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import ListenLater from '@/app/components/ListenLater';
 
 export const metadata = {
   title: 'How to feel when your startup feels easy — Gareth MacLeod',
@@ -29,6 +30,8 @@ export default function HowToFeelPost() {
         <p className="font-sans text-[0.82rem] text-[#888] mb-8">March 2024</p>
 
         <hr />
+
+        <ListenLater slug="how-to-feel-when-your-startup-feels-easy" />
 
         <p>
           I did something hard once: I took my startup from zero to $1m in daily volume in 4 months.

--- a/app/blog/i-worked-with-a-man-who-faked-his-own-death/page.tsx
+++ b/app/blog/i-worked-with-a-man-who-faked-his-own-death/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import ListenLater from '@/app/components/ListenLater';
 
 export const metadata = {
   title: 'I worked with a man who faked his own death — Gareth MacLeod',
@@ -29,6 +30,8 @@ export default function FakedDeathPost() {
         <p className="font-sans text-[0.82rem] text-[#888] mb-8">June 2024</p>
 
         <hr />
+
+        <ListenLater slug="i-worked-with-a-man-who-faked-his-own-death" />
 
         <p>
           I only spoke with Gerald Cotton on the phone, but we had substantial business dealings with him for a time. He ran one of the Canadian exchanges, which had low volume but highly arbitrageable orders, so we made a tidy profit trading there, and added substantial liquidity to their books, so it was a profitable relationship for both parties.

--- a/app/blog/its-the-money-silly/page.tsx
+++ b/app/blog/its-the-money-silly/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import ListenLater from '@/app/components/ListenLater';
 
 export const metadata = {
   title: "It's the money, silly — Gareth MacLeod",
@@ -29,6 +30,8 @@ export default function ItsTheMoneySillyPost() {
         <p className="font-sans text-[0.82rem] text-[#888] mb-8">November 2025</p>
 
         <hr />
+
+        <ListenLater slug="its-the-money-silly" />
 
         <p>
           People have been talking about the shortcomings of the Canadian tech startup world my whole professional life, with Silicon Valley the bar against which we measure ourselves. With renewed heat on this topic in the tariff era, two problems in particular have received a lot of attention: our <em>unambitious</em> culture, and our constant leakage of good talent <em>to</em> Silicon Valley. Both of these are worth discussing, but as causal explanations for our differences to California, they are weak and incomplete. What is missing from this framework is money.

--- a/app/blog/surviving-five-years-in-the-most-dangerous-market/page.tsx
+++ b/app/blog/surviving-five-years-in-the-most-dangerous-market/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import ListenLater from '@/app/components/ListenLater';
 
 export const metadata = {
   title: 'Thriving in the presence of risk — Crypto 2013–17 — Gareth MacLeod',
@@ -29,6 +30,8 @@ export default function SurvivingFiveYearsPost() {
         <p className="font-sans text-[0.82rem] text-[#888] mb-8">August 2019</p>
 
         <hr />
+
+        <ListenLater slug="surviving-five-years-in-the-most-dangerous-market" />
 
         <p>
           The goal of Tinker was to build the Goldman Sachs of the blockchain-future, and our thesis was

--- a/app/components/ListenLater.tsx
+++ b/app/components/ListenLater.tsx
@@ -1,0 +1,77 @@
+import {
+  EpisodeSlug,
+  getPodcastEpisode,
+  podcastConfig,
+} from '@/app/lib/podcast';
+import SharePodcastButton from './SharePodcastButton';
+
+type ListenLaterProps = {
+  slug: EpisodeSlug;
+};
+
+function formatDuration(totalSeconds: number): string {
+  const minutes = Math.max(1, Math.round(totalSeconds / 60));
+  return `${minutes} min`;
+}
+
+export default function ListenLater({ slug }: ListenLaterProps) {
+  const episode = getPodcastEpisode(slug);
+  const audio = episode.audio;
+  const isAvailable = audio !== null;
+
+  return (
+    <aside className="listen-later" aria-labelledby={`listen-${slug}`}>
+      <p className="listen-eyebrow">
+        {isAvailable ? 'Audio edition' : 'Listen later · audio edition planned'}
+      </p>
+      <h2 id={`listen-${slug}`} className="listen-title">
+        Take this essay with you
+      </h2>
+      <p className="listen-copy">
+        {isAvailable
+          ? `Listen here or follow the feed in your usual podcast app. ${formatDuration(
+              audio.durationSeconds,
+            )}.`
+          : 'Follow the RSS feed now and the spoken edition will arrive in your podcast app when it is published.'}
+      </p>
+      <div className="listen-actions">
+        {podcastConfig.directoryLinks.apple && (
+          <a
+            className="listen-action"
+            href={podcastConfig.directoryLinks.apple}
+            rel="noreferrer"
+          >
+            Apple Podcasts
+          </a>
+        )}
+        {podcastConfig.directoryLinks.spotify && (
+          <a
+            className="listen-action"
+            href={podcastConfig.directoryLinks.spotify}
+            rel="noreferrer"
+          >
+            Spotify
+          </a>
+        )}
+        {audio && (
+          <a className="listen-action" href={audio.url}>
+            Play MP3
+          </a>
+        )}
+        <a
+          className="listen-action listen-action-primary"
+          href={podcastConfig.feedPath}
+        >
+          Podcast RSS
+        </a>
+        <SharePodcastButton feedUrl={podcastConfig.feedUrl} />
+      </div>
+      {!isAvailable && (
+        <p className="listen-note">
+          Apple Podcasts and Spotify links will appear after the first episode
+          is live.
+        </p>
+      )}
+    </aside>
+  );
+}

--- a/app/components/PodcastPromo.tsx
+++ b/app/components/PodcastPromo.tsx
@@ -1,0 +1,55 @@
+import { podcastConfig } from '@/app/lib/podcast';
+import SharePodcastButton from './SharePodcastButton';
+
+export default function PodcastPromo() {
+  const hasDirectoryLink =
+    podcastConfig.directoryLinks.apple ||
+    podcastConfig.directoryLinks.spotify;
+
+  return (
+    <section className="podcast-promo" aria-labelledby="audio-essays">
+      <p className="listen-eyebrow">Listen later</p>
+      <h2 id="audio-essays" className="podcast-promo-title">
+        Writing, away from the screen
+      </h2>
+      <p className="podcast-promo-copy">
+        Spoken editions of these essays are coming to a public podcast feed.
+        Follow once, then listen on a walk, in the car, or wherever you already
+        keep your podcasts.
+      </p>
+      <div className="listen-actions">
+        {podcastConfig.directoryLinks.apple && (
+          <a
+            className="listen-action"
+            href={podcastConfig.directoryLinks.apple}
+            rel="noreferrer"
+          >
+            Apple Podcasts
+          </a>
+        )}
+        {podcastConfig.directoryLinks.spotify && (
+          <a
+            className="listen-action"
+            href={podcastConfig.directoryLinks.spotify}
+            rel="noreferrer"
+          >
+            Spotify
+          </a>
+        )}
+        <a
+          className="listen-action listen-action-primary"
+          href={podcastConfig.feedPath}
+        >
+          Follow via RSS
+        </a>
+        <SharePodcastButton feedUrl={podcastConfig.feedUrl} />
+      </div>
+      {!hasDirectoryLink && (
+        <p className="listen-note">
+          Podcast-app links will be added after the first recording is
+          published.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/app/components/SharePodcastButton.tsx
+++ b/app/components/SharePodcastButton.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useState } from 'react';
+
+type SharePodcastButtonProps = {
+  feedUrl: string;
+};
+
+export default function SharePodcastButton({
+  feedUrl,
+}: SharePodcastButtonProps) {
+  const [label, setLabel] = useState('Send to phone');
+
+  async function shareFeed() {
+    try {
+      if (navigator.share) {
+        await navigator.share({
+          title: 'Gareth MacLeod — Audio Essays',
+          text: 'Save this podcast feed and listen to new audio essays away from the website.',
+          url: feedUrl,
+        });
+        return;
+      }
+
+      await navigator.clipboard.writeText(feedUrl);
+      setLabel('Feed link copied');
+      window.setTimeout(() => setLabel('Send to phone'), 2200);
+    } catch (error) {
+      // Closing the native share sheet is not an error the reader needs to see.
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        return;
+      }
+
+      window.location.href = `mailto:?subject=${encodeURIComponent(
+        'Gareth MacLeod — Audio Essays',
+      )}&body=${encodeURIComponent(feedUrl)}`;
+    }
+  }
+
+  return (
+    <button type="button" className="listen-action" onClick={shareFeed}>
+      {label}
+    </button>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -63,3 +63,89 @@ p {
   margin-top: 0;
   margin-bottom: 1.1rem;
 }
+
+.listen-later,
+.podcast-promo {
+  border-top: 1px solid #dce3ed;
+  border-bottom: 1px solid #dce3ed;
+  background: #fafbfd;
+  padding: 1.1rem 1.2rem 1rem;
+}
+
+.listen-later {
+  margin: 0 0 2rem;
+}
+
+.podcast-promo {
+  margin: 2rem 0 0;
+}
+
+.listen-eyebrow {
+  color: #4a6fa5;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 0.72rem;
+  font-weight: 650;
+  letter-spacing: 0.075em;
+  margin: 0 0 0.3rem;
+  text-transform: uppercase;
+}
+
+.listen-title,
+.podcast-promo-title {
+  font-size: 1rem;
+  margin: 0 0 0.35rem;
+}
+
+.listen-copy,
+.podcast-promo-copy {
+  color: #444;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 0.85rem;
+  line-height: 1.55;
+  margin: 0 0 0.8rem;
+}
+
+.listen-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.listen-action {
+  appearance: none;
+  background: #fff;
+  border: 1px solid #c8d3e1;
+  border-radius: 999px;
+  color: #3e6394;
+  cursor: pointer;
+  display: inline-flex;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 0.75rem;
+  line-height: 1;
+  padding: 0.48rem 0.72rem;
+}
+
+.listen-action:hover {
+  border-color: #4a6fa5;
+  text-decoration: none;
+}
+
+.listen-action-primary {
+  background: #4a6fa5;
+  border-color: #4a6fa5;
+  color: #fff;
+}
+
+.listen-action-primary:hover {
+  background: #3e6394;
+  color: #fff;
+}
+
+.listen-note {
+  color: #777;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 0.7rem;
+  line-height: 1.45;
+  margin: 0.65rem 0 0;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { podcastConfig } from '@/app/lib/podcast';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -13,6 +14,14 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
+      <head>
+        <link
+          rel="alternate"
+          type="application/rss+xml"
+          title={podcastConfig.title}
+          href={podcastConfig.feedUrl}
+        />
+      </head>
       <body>
         {children}
         <script

--- a/app/lib/podcast.ts
+++ b/app/lib/podcast.ts
@@ -1,0 +1,119 @@
+export type PodcastDirectoryLinks = {
+  apple: string | null;
+  spotify: string | null;
+};
+
+export type PodcastAudio = {
+  url: string;
+  byteLength: number;
+  mimeType: 'audio/mpeg' | 'audio/mp4';
+  durationSeconds: number;
+  publishedAt: string;
+};
+
+export type PodcastEpisode = {
+  slug: EpisodeSlug;
+  title: string;
+  description: string;
+  guid: string;
+  audio: PodcastAudio | null;
+};
+
+export type EpisodeSlug =
+  | 'its-the-money-silly'
+  | 'i-worked-with-a-man-who-faked-his-own-death'
+  | 'how-to-feel-when-your-startup-feels-easy'
+  | 'surviving-five-years-in-the-most-dangerous-market';
+
+const siteUrl = (
+  process.env.NEXT_PUBLIC_SITE_URL ||
+  'https://garethdmm.com'
+).replace(/\/$/, '');
+
+export const podcastConfig = {
+  title: 'Gareth MacLeod — Audio Essays',
+  description:
+    'Spoken editions of Gareth MacLeod’s writing on startups, technology, money, and risk.',
+  author: 'Gareth MacLeod',
+  ownerEmail: 'gareth.macleod@gmail.com',
+  language: 'en-CA',
+  category: 'Technology',
+  explicit: false,
+  siteUrl,
+  feedPath: '/podcast.xml',
+  feedUrl: `${siteUrl}/podcast.xml`,
+  artworkUrl: null as string | null,
+  directoryLinks: {
+    apple: null,
+    spotify: null,
+  } satisfies PodcastDirectoryLinks,
+  updatedAt: '2026-07-28T12:00:00-04:00',
+} as const;
+
+// An episode is added to the public feed only when all enclosure metadata is
+// present. Until then, the matching article shows the honest pre-launch state.
+export const podcastEpisodes: PodcastEpisode[] = [
+  {
+    slug: 'its-the-money-silly',
+    title: "It's the money, silly",
+    description:
+      'Why capital density, not founder ambition, is the missing variable in conversations about Canadian startups.',
+    guid: 'garethmacleod-audio-its-the-money-silly',
+    audio: null,
+  },
+  {
+    slug: 'i-worked-with-a-man-who-faked-his-own-death',
+    title: 'I worked with a man who faked his own death',
+    description:
+      'A first-hand connection to the Quadriga collapse, and a story about risk, fraud, and repeatedly turning away from redemption.',
+    guid: 'garethmacleod-audio-i-worked-with-a-man-who-faked-his-own-death',
+    audio: null,
+  },
+  {
+    slug: 'how-to-feel-when-your-startup-feels-easy',
+    title: 'How to feel when your startup feels easy',
+    description:
+      'Why ease can be a signal that a startup has found something people want, rather than evidence that its founders are frauds.',
+    guid: 'garethmacleod-audio-how-to-feel-when-your-startup-feels-easy',
+    audio: null,
+  },
+  {
+    slug: 'surviving-five-years-in-the-most-dangerous-market',
+    title: 'Thriving in the presence of risk — Crypto 2013–17',
+    description:
+      'How a cryptocurrency trading company used threat modelling, limits, and an acceptance of uncertainty to survive a hostile market.',
+    guid:
+      'garethmacleod-audio-surviving-five-years-in-the-most-dangerous-market',
+    audio: null,
+  },
+];
+
+export function getPodcastEpisode(slug: EpisodeSlug): PodcastEpisode {
+  const episode = podcastEpisodes.find((candidate) => candidate.slug === slug);
+
+  if (!episode) {
+    throw new Error(`No podcast episode configured for "${slug}".`);
+  }
+
+  return episode;
+}
+
+export function getPublishedPodcastEpisodes(): PodcastEpisode[] {
+  return podcastEpisodes
+    .filter(
+      (
+        episode,
+      ): episode is PodcastEpisode & {
+        audio: PodcastAudio;
+      } => episode.audio !== null,
+    )
+    .sort(
+      (left, right) =>
+        new Date(right.audio.publishedAt).getTime() -
+        new Date(left.audio.publishedAt).getTime(),
+    );
+}
+
+export function articleUrl(slug: EpisodeSlug): string {
+  return `${podcastConfig.siteUrl}/blog/${slug}`;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import PodcastPromo from '@/app/components/PodcastPromo';
 
 export default function Home() {
   return (
@@ -28,6 +29,8 @@ export default function Home() {
             <a href="mailto:gareth.macleod@gmail.com">email</a>
           </p>
         </div>
+
+        <PodcastPromo />
 
         <hr />
 

--- a/app/podcast.xml/route.ts
+++ b/app/podcast.xml/route.ts
@@ -1,0 +1,91 @@
+import {
+  articleUrl,
+  getPublishedPodcastEpisodes,
+  podcastConfig,
+} from '@/app/lib/podcast';
+
+export const dynamic = 'force-static';
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+function formatDuration(totalSeconds: number): string {
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const padded = (value: number) => value.toString().padStart(2, '0');
+
+  return hours > 0
+    ? `${hours}:${padded(minutes)}:${padded(seconds)}`
+    : `${minutes}:${padded(seconds)}`;
+}
+
+export function GET() {
+  const episodes = getPublishedPodcastEpisodes();
+  const latestUpdate =
+    episodes[0]?.audio?.publishedAt ?? podcastConfig.updatedAt;
+  const artwork = podcastConfig.artworkUrl
+    ? `\n    <itunes:image href="${escapeXml(podcastConfig.artworkUrl)}" />`
+    : '';
+  const items = episodes
+    .map((episode) => {
+      const audio = episode.audio;
+
+      if (!audio) {
+        return '';
+      }
+
+      return `
+    <item>
+      <title>${escapeXml(episode.title)}</title>
+      <link>${escapeXml(articleUrl(episode.slug))}</link>
+      <guid isPermaLink="false">${escapeXml(episode.guid)}</guid>
+      <description>${escapeXml(episode.description)}</description>
+      <pubDate>${new Date(audio.publishedAt).toUTCString()}</pubDate>
+      <enclosure url="${escapeXml(audio.url)}" length="${audio.byteLength}" type="${audio.mimeType}" />
+      <itunes:author>${escapeXml(podcastConfig.author)}</itunes:author>
+      <itunes:explicit>${podcastConfig.explicit}</itunes:explicit>
+      <itunes:duration>${formatDuration(audio.durationSeconds)}</itunes:duration>
+      <itunes:episodeType>full</itunes:episodeType>
+    </item>`;
+    })
+    .join('');
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+  xmlns:atom="http://www.w3.org/2005/Atom"
+  xmlns:content="http://purl.org/rss/1.0/modules/content/"
+  xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+  <channel>
+    <title>${escapeXml(podcastConfig.title)}</title>
+    <link>${escapeXml(podcastConfig.siteUrl)}</link>
+    <description>${escapeXml(podcastConfig.description)}</description>
+    <language>${podcastConfig.language}</language>
+    <lastBuildDate>${new Date(latestUpdate).toUTCString()}</lastBuildDate>
+    <atom:link href="${escapeXml(podcastConfig.feedUrl)}" rel="self" type="application/rss+xml" />
+    <itunes:author>${escapeXml(podcastConfig.author)}</itunes:author>
+    <itunes:summary>${escapeXml(podcastConfig.description)}</itunes:summary>
+    <itunes:explicit>${podcastConfig.explicit}</itunes:explicit>
+    <itunes:type>episodic</itunes:type>
+    <itunes:category text="${escapeXml(podcastConfig.category)}" />
+    <itunes:owner>
+      <itunes:name>${escapeXml(podcastConfig.author)}</itunes:name>
+      <itunes:email>${escapeXml(podcastConfig.ownerEmail)}</itunes:email>
+    </itunes:owner>${artwork}${items}
+  </channel>
+</rss>
+`;
+
+  return new Response(xml, {
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+}

--- a/docs/podcast-setup.md
+++ b/docs/podcast-setup.md
@@ -1,0 +1,97 @@
+# Podcast setup
+
+The site now exports a well-formed, public RSS document at `/podcast.xml`.
+It is deliberately a **pre-launch feed**, not yet a submission-ready podcast:
+there is no artwork and there are no audio enclosures until real assets are
+configured.
+
+The website is useful before launch:
+
+- every essay advertises the planned audio edition;
+- readers can follow or share the RSS URL now;
+- Apple Podcasts and Spotify are shown as “after launch,” not as broken links;
+- feed discovery metadata is present in every page `<head>`.
+
+## 1. Produce and host the first recording
+
+Create a final MP3, then upload it to durable public object storage or a
+podcast host. Do not commit large recordings to this repository. The final URL
+must:
+
+- use HTTPS and remain stable;
+- return the exact `Content-Length` for a `HEAD` request;
+- support byte-range requests (`206 Partial Content`);
+- use a unique URL for each episode;
+- return an audio MIME type such as `audio/mpeg`.
+
+Verify the host before editing the feed:
+
+```sh
+curl -I https://audio.example.com/episode.mp3
+curl -sS -D - -o /dev/null -H 'Range: bytes=0-1023' https://audio.example.com/episode.mp3
+wc -c episode.mp3
+ffprobe -v error -show_entries format=duration -of csv=p=0 episode.mp3
+```
+
+The first request should report `200`, `Content-Length`, and `audio/mpeg`. The
+range request should report `206`. `wc -c` supplies `byteLength`; round the
+`ffprobe` result to a whole number for `durationSeconds`.
+
+## 2. Complete the central configuration
+
+All editable podcast data is in `app/lib/podcast.ts`.
+
+1. Confirm `podcastConfig.siteUrl`. The default is the production site,
+   `https://garethdmm.com`. Set `NEXT_PUBLIC_SITE_URL` at build time for a
+   preview or a future domain change; omit the trailing slash.
+2. Upload square JPEG or PNG show artwork. A 3000 × 3000 image is a safe shared
+   target for Apple and Spotify. Set its permanent HTTPS URL as `artworkUrl`.
+3. Confirm the show title, description, author, owner email, language,
+   `category`, and explicit-content setting.
+4. Replace the relevant episode’s `audio: null` with:
+
+```ts
+audio: {
+  url: 'https://audio.example.com/episode.mp3',
+  byteLength: 12345678,
+  mimeType: 'audio/mpeg',
+  durationSeconds: 742,
+  publishedAt: '2026-08-01T09:00:00-04:00',
+},
+```
+
+Keep each existing `guid` unchanged after publication. A stable, unique GUID is
+how podcast apps recognize an episode across feed refreshes.
+
+Then run `npm run build` and inspect `out/podcast.xml`. A submission-ready feed
+needs, at minimum:
+
+- public artwork;
+- at least one `<item>`;
+- a stable GUID for every item;
+- a unique enclosure URL, exact byte length, and correct MIME type;
+- an audio host that passes the `HEAD` and byte-range checks above.
+
+## 3. Submit the same feed to directories
+
+After the first episode and artwork are live, submit the public feed URL:
+
+`https://garethdmm.com/podcast.xml`
+
+- Apple Podcasts Connect: <https://podcastsconnect.apple.com/>
+- Spotify for Creators: <https://creators.spotify.com/>
+
+If `NEXT_PUBLIC_SITE_URL` changes, submit the resulting
+`{NEXT_PUBLIC_SITE_URL}/podcast.xml` instead. Complete ownership verification
+using the email in `ownerEmail`. After approval, paste the public show URLs into
+`directoryLinks.apple` and `directoryLinks.spotify`; the site will then render
+real directory buttons everywhere.
+
+## 4. Voice options
+
+The simplest, highest-trust version is Gareth reading each essay and exporting
+an edited MP3. A voice clone can be a later production step: train only on
+Gareth’s recordings with his explicit consent, review the entire render, and
+export the final MP3 before deploying. Keep provider credentials and synthesis
+outside this static site—the website needs only the finished audio URL and
+metadata above.


### PR DESCRIPTION
## Concept

This draft explores a subscription-first version of “listen later”: rather than asking readers to keep a browser tab open, they can follow one public podcast feed and receive spoken editions in the audio apps they already use. Native share/copy is deliberately secondary to that follow-once story.

## What works now

- Adds one restrained, reusable listen-later CTA to all four essays, matching the site’s Georgia typography, blue accent, and quiet layout.
- Adds a homepage audio-essay promotion and RSS discovery metadata in every page `<head>`.
- Statically exports a real RSS 2.0 document at `/podcast.xml`, compatible with the existing Next 14 GitHub Pages build.
- Centralizes show metadata, episode metadata, stable GUIDs, directory URLs, and enclosure data in `app/lib/podcast.ts`.
- Emits an episode only when its full audio enclosure is configured, preventing partial or invalid podcast items.
- Adds native Web Share with clipboard and email fallbacks so a reader can move the feed to their phone.
- Conditionally exposes Apple Podcasts, Spotify, and direct MP3 links only after real URLs exist.

## Honest pre-launch state

No recording, show artwork, or directory listing exists yet. The exported XML is therefore a well-formed **pre-launch feed**, not a submission-ready podcast: it intentionally contains no `<item>`, `<enclosure>`, or `<itunes:image>` nodes, and the UI describes audio editions and directory links as planned. No fake MP3 or placeholder Apple/Spotify URL is shipped.

## Manual setup remaining

The exact checklist is in `docs/podcast-setup.md`:

1. Record an essay (or produce and fully review a consented voice-clone render) and export the final MP3 outside the static site.
2. Host each MP3 at a permanent HTTPS URL that reports the exact byte length and MIME type and supports `HEAD` and byte-range requests.
3. Upload square show artwork; 3000 × 3000 JPEG/PNG is the documented shared target.
4. Fill the episode URL, byte length, MIME type, duration, and publication date in the central config, then rebuild.
5. Submit `https://garethdmm.com/podcast.xml` through Apple Podcasts Connect and Spotify for Creators after artwork and at least one complete episode are live.
6. Add the approved Apple and Spotify show URLs to the config so real directory buttons appear throughout the site.

## Validation

- `npm run build` — passes type checking, linting, static generation, and exports `/podcast.xml`.
- Parsed the exported XML and confirmed it contains an RSS channel.
- Asserted the pre-launch feed contains no item, enclosure, or artwork nodes.
- Asserted all four exported blog pages contain the listen-later CTA.
- GitHub compare: one commit ahead of `main`, zero behind, with only the 14 intended files changed.

## Tradeoffs

- Before directory approval, RSS is the only subscription target and is more technical than an Apple/Spotify button; the UI says those app links are forthcoming.
- Audio synthesis and hosting stay outside the static build, keeping credentials and large media out of this repository but requiring a small publishing step per episode.
- This PR establishes the distribution and UI contract without choosing an audio host or voice provider, so those decisions remain reversible.