### PR TITLE
Add take-with-you audio editions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 Gareth's personal website circa 2026. Intended to be a small collection of works and offramps to other source like github.
+
+Audio editions are configured as static MP3s. See
+[`docs/AUDIO_SETUP.md`](docs/AUDIO_SETUP.md) for the publishing workflow.

--- a/app/audio-posts.ts
+++ b/app/audio-posts.ts
@@ -1,0 +1,39 @@
+export type AudioPost = {
+  title: string;
+  src: string | null;
+  fileName: string;
+  duration: string | null;
+};
+
+export const audioPosts = {
+  'its-the-money-silly': {
+    title: "It's the money, silly",
+    src: null,
+    fileName: 'its-the-money-silly.mp3',
+    duration: null,
+  },
+  'i-worked-with-a-man-who-faked-his-own-death': {
+    title: 'I worked with a man who faked his own death',
+    src: null,
+    fileName: 'i-worked-with-a-man-who-faked-his-own-death.mp3',
+    duration: null,
+  },
+  'how-to-feel-when-your-startup-feels-easy': {
+    title: 'How to feel when your startup feels easy',
+    src: null,
+    fileName: 'how-to-feel-when-your-startup-feels-easy.mp3',
+    duration: null,
+  },
+  'surviving-five-years-in-the-most-dangerous-market': {
+    title: 'Thriving in the presence of risk — Crypto 2013–17',
+    src: null,
+    fileName: 'surviving-five-years-in-the-most-dangerous-market.mp3',
+    duration: null,
+  },
+} satisfies Record<string, AudioPost>;
+
+export type AudioPostSlug = keyof typeof audioPosts;
+
+export const hasPublishedAudio = Object.values(audioPosts).some(
+  (post) => post.src !== null,
+);

--- a/app/blog/how-to-feel-when-your-startup-feels-easy/page.tsx
+++ b/app/blog/how-to-feel-when-your-startup-feels-easy/page.tsx
@@ -1,4 +1,6 @@
 import Link from 'next/link';
+import TakeWithYou from '../../components/TakeWithYou';
+import { audioPosts } from '../../audio-posts';
 
 export const metadata = {
   title: 'How to feel when your startup feels easy — Gareth MacLeod',
@@ -27,6 +29,8 @@ export default function HowToFeelPost() {
           How to feel when your startup feels easy
         </h1>
         <p className="font-sans text-[0.82rem] text-[#888] mb-8">March 2024</p>
+
+        <TakeWithYou audio={audioPosts['how-to-feel-when-your-startup-feels-easy']} />
 
         <hr />
 

--- a/app/blog/i-worked-with-a-man-who-faked-his-own-death/page.tsx
+++ b/app/blog/i-worked-with-a-man-who-faked-his-own-death/page.tsx
@@ -1,4 +1,6 @@
 import Link from 'next/link';
+import TakeWithYou from '../../components/TakeWithYou';
+import { audioPosts } from '../../audio-posts';
 
 export const metadata = {
   title: 'I worked with a man who faked his own death — Gareth MacLeod',
@@ -27,6 +29,8 @@ export default function FakedDeathPost() {
           I worked with a man who faked his own death
         </h1>
         <p className="font-sans text-[0.82rem] text-[#888] mb-8">June 2024</p>
+
+        <TakeWithYou audio={audioPosts['i-worked-with-a-man-who-faked-his-own-death']} />
 
         <hr />
 

--- a/app/blog/its-the-money-silly/page.tsx
+++ b/app/blog/its-the-money-silly/page.tsx
@@ -1,4 +1,6 @@
 import Link from 'next/link';
+import TakeWithYou from '../../components/TakeWithYou';
+import { audioPosts } from '../../audio-posts';
 
 export const metadata = {
   title: "It's the money, silly — Gareth MacLeod",
@@ -27,6 +29,8 @@ export default function ItsTheMoneySillyPost() {
           It's the money, silly
         </h1>
         <p className="font-sans text-[0.82rem] text-[#888] mb-8">November 2025</p>
+
+        <TakeWithYou audio={audioPosts['its-the-money-silly']} />
 
         <hr />
 

--- a/app/blog/surviving-five-years-in-the-most-dangerous-market/page.tsx
+++ b/app/blog/surviving-five-years-in-the-most-dangerous-market/page.tsx
@@ -1,4 +1,6 @@
 import Link from 'next/link';
+import TakeWithYou from '../../components/TakeWithYou';
+import { audioPosts } from '../../audio-posts';
 
 export const metadata = {
   title: 'Thriving in the presence of risk — Crypto 2013–17 — Gareth MacLeod',
@@ -27,6 +29,8 @@ export default function SurvivingFiveYearsPost() {
           Thriving in the presence of risk — Crypto 2013–17
         </h1>
         <p className="font-sans text-[0.82rem] text-[#888] mb-8">August 2019</p>
+
+        <TakeWithYou audio={audioPosts['surviving-five-years-in-the-most-dangerous-market']} />
 
         <hr />
 

--- a/app/components/TakeWithYou.tsx
+++ b/app/components/TakeWithYou.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { useState } from 'react';
+import type { AudioPost } from '../audio-posts';
+
+type TakeWithYouProps = {
+  audio: AudioPost;
+};
+
+function absoluteAudioUrl(src: string) {
+  return new URL(src, window.location.origin).toString();
+}
+
+async function copyText(value: string) {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(value);
+    return;
+  }
+
+  const textArea = document.createElement('textarea');
+  textArea.value = value;
+  textArea.setAttribute('readonly', '');
+  textArea.style.position = 'fixed';
+  textArea.style.opacity = '0';
+  document.body.appendChild(textArea);
+  textArea.select();
+  const copied = document.execCommand('copy');
+  textArea.remove();
+
+  if (!copied) {
+    throw new Error('Copy failed');
+  }
+}
+
+function wasCancelled(error: unknown) {
+  return error instanceof DOMException && error.name === 'AbortError';
+}
+
+export default function TakeWithYou({ audio }: TakeWithYouProps) {
+  const [status, setStatus] = useState('');
+  const [isSharing, setIsSharing] = useState(false);
+  const audioSrc = audio.src;
+
+  if (!audioSrc) {
+    return (
+      <aside className="audio-takeaway audio-takeaway-unavailable" aria-label="Audio edition">
+        <p className="audio-eyebrow">Take this essay with you</p>
+        <p className="audio-description">
+          The audio edition is being recorded. When it is ready, you will be able to
+          listen here, download the MP3, or send it to another device—without making
+          an account.
+        </p>
+      </aside>
+    );
+  }
+
+  const handleCopy = async () => {
+    try {
+      await copyText(absoluteAudioUrl(audioSrc));
+      setStatus('Audio link copied.');
+    } catch {
+      setStatus('Could not copy the link. Try Download or Email instead.');
+    }
+  };
+
+  const handleEmail = () => {
+    const url = absoluteAudioUrl(audioSrc);
+    const subject = `Listen later: ${audio.title}`;
+    const body = `Here is the audio edition of “${audio.title}”:\n\n${url}`;
+    window.location.href = `mailto:?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+  };
+
+  const handleShare = async () => {
+    const url = absoluteAudioUrl(audioSrc);
+    setIsSharing(true);
+    setStatus('');
+
+    if (!navigator.share) {
+      try {
+        await copyText(url);
+        setStatus('Your browser has no share menu, so the audio link was copied.');
+      } catch {
+        setStatus('Sharing is unavailable here. Try Download, Copy link, or Email.');
+      } finally {
+        setIsSharing(false);
+      }
+      return;
+    }
+
+    try {
+      try {
+        const response = await fetch(audioSrc);
+        if (response.ok) {
+          const blob = await response.blob();
+          const file = new File([blob], audio.fileName, {
+            type: blob.type || 'audio/mpeg',
+          });
+
+          if (navigator.canShare?.({ files: [file] })) {
+            try {
+              await navigator.share({
+                title: audio.title,
+                files: [file],
+              });
+              setStatus('Audio shared.');
+              return;
+            } catch (error) {
+              if (wasCancelled(error)) {
+                return;
+              }
+              // File sharing can fail even when URL sharing works; continue below.
+            }
+          }
+        }
+      } catch {
+        // The direct file fetch is an enhancement. URL sharing still works.
+      }
+
+      await navigator.share({
+        title: audio.title,
+        text: `Listen to “${audio.title}”`,
+        url,
+      });
+      setStatus('Audio link shared.');
+    } catch (error) {
+      if (wasCancelled(error)) {
+        return;
+      }
+
+      try {
+        await copyText(url);
+        setStatus('The share menu did not open, so the audio link was copied.');
+      } catch {
+        setStatus('Sharing is unavailable here. Try Download, Copy link, or Email.');
+      }
+    } finally {
+      setIsSharing(false);
+    }
+  };
+
+  return (
+    <aside className="audio-takeaway" aria-labelledby="audio-takeaway-title">
+      <div className="audio-heading">
+        <p className="audio-eyebrow" id="audio-takeaway-title">
+          Take this essay with you
+        </p>
+        {audio.duration && <span className="audio-duration">{audio.duration}</span>}
+      </div>
+
+      <p className="audio-description">
+        Listen here, or keep the MP3 for your commute, a walk, or later.
+      </p>
+
+      <audio className="audio-player" controls preload="metadata">
+        <source src={audioSrc} type="audio/mpeg" />
+        Your browser does not support embedded audio. Download the MP3 instead.
+      </audio>
+
+      <div className="audio-actions" aria-label="Ways to take this essay with you">
+        <a
+          className="audio-action audio-action-primary"
+          href={audioSrc}
+          download={audio.fileName}
+        >
+          Download MP3
+        </a>
+        <button
+          className="audio-action"
+          type="button"
+          onClick={handleShare}
+          disabled={isSharing}
+        >
+          {isSharing ? 'Preparing…' : 'Send / share'}
+        </button>
+        <button className="audio-action" type="button" onClick={handleCopy}>
+          Copy link
+        </button>
+        <button className="audio-action" type="button" onClick={handleEmail}>
+          Email to myself
+        </button>
+      </div>
+
+      <p className="audio-note">
+        Downloads open in ordinary audio players. Send / share uses your device&apos;s
+        share menu when available.
+      </p>
+      <p className="audio-status" role="status" aria-live="polite">
+        {status}
+      </p>
+    </aside>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -63,3 +63,167 @@ p {
   margin-top: 0;
   margin-bottom: 1.1rem;
 }
+
+.listen-later-note {
+  border-left: 3px solid #4a6fa5;
+  background: #f7f9fc;
+  margin: 0 0 2rem;
+  padding: 0.9rem 1rem;
+}
+
+.listen-later-note p:last-child {
+  margin-bottom: 0;
+}
+
+.listen-later-title {
+  color: #4a6fa5;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.2rem;
+  text-transform: uppercase;
+}
+
+.listen-later-copy {
+  color: #444;
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+.audio-list-badge {
+  border: 1px solid #b9c9dc;
+  border-radius: 999px;
+  color: #4a6fa5;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  margin-right: 0.35rem;
+  padding: 0.08rem 0.4rem;
+  text-transform: uppercase;
+}
+
+.audio-takeaway {
+  background: #f7f9fc;
+  border: 1px solid #d8e1ec;
+  border-left: 3px solid #4a6fa5;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 1.6rem 0 2rem;
+  padding: 1rem 1.1rem 0.85rem;
+}
+
+.audio-takeaway-unavailable {
+  background: #fafafa;
+  border-color: #e1e1e1;
+  border-left-color: #9ca9b9;
+}
+
+.audio-heading {
+  align-items: baseline;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.audio-eyebrow {
+  color: #2f578b;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  margin-bottom: 0.25rem;
+  text-transform: uppercase;
+}
+
+.audio-duration {
+  color: #777;
+  flex-shrink: 0;
+  font-size: 0.76rem;
+}
+
+.audio-description {
+  color: #444;
+  font-family: Georgia, 'Times New Roman', Times, serif;
+  font-size: 0.94rem;
+  line-height: 1.55;
+  margin-bottom: 0.8rem;
+}
+
+.audio-player {
+  display: block;
+  height: 42px;
+  margin: 0.35rem 0 0.9rem;
+  width: 100%;
+}
+
+.audio-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.audio-action {
+  align-items: center;
+  appearance: none;
+  background: #fff;
+  border: 1px solid #aebed1;
+  border-radius: 3px;
+  color: #3f6492;
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  font-size: 0.76rem;
+  font-weight: 600;
+  justify-content: center;
+  line-height: 1.2;
+  min-height: 2.15rem;
+  padding: 0.45rem 0.65rem;
+  text-decoration: none;
+}
+
+.audio-action:hover {
+  background: #eef3f8;
+  text-decoration: none;
+}
+
+.audio-action:focus-visible {
+  outline: 2px solid #4a6fa5;
+  outline-offset: 2px;
+}
+
+.audio-action:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.audio-action-primary {
+  background: #4a6fa5;
+  border-color: #4a6fa5;
+  color: #fff;
+}
+
+.audio-action-primary:hover {
+  background: #3e608e;
+}
+
+.audio-note {
+  color: #777;
+  font-size: 0.7rem;
+  line-height: 1.45;
+  margin: 0.75rem 0 0;
+}
+
+.audio-status {
+  color: #355a87;
+  font-size: 0.72rem;
+  font-weight: 600;
+  line-height: 1.4;
+  margin: 0.25rem 0 0;
+  min-height: 1em;
+}
+
+@media (max-width: 480px) {
+  .audio-action {
+    flex: 1 1 calc(50% - 0.45rem);
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { audioPosts, hasPublishedAudio } from './audio-posts';
 
 export default function Home() {
   return (
@@ -31,6 +32,15 @@ export default function Home() {
 
         <hr />
 
+        <aside className="listen-later-note" aria-labelledby="listen-later-title">
+          <p className="listen-later-title" id="listen-later-title">Listen later</p>
+          <p className="listen-later-copy">
+            {hasPublishedAudio
+              ? 'Take an essay on a walk: listen here, download the MP3, or send it to another device.'
+              : 'Audio editions are being recorded. Soon you will be able to listen here, download the MP3, or send an essay to another device.'}
+          </p>
+        </aside>
+
         {/* Writing */}
         <section>
           <h2 className="text-base font-sans font-semibold uppercase tracking-[0.06em] text-[#888] mt-0">
@@ -41,25 +51,37 @@ export default function Home() {
               <Link href="/blog/its-the-money-silly" className="flex-1">
                 It's the money, silly
               </Link>
-              <span className="font-sans text-[0.82rem] text-[#888] shrink-0">Nov 2025</span>
+              <span className="font-sans text-[0.82rem] text-[#888] shrink-0">
+                {audioPosts['its-the-money-silly'].src && <span className="audio-list-badge">Audio</span>}
+                Nov 2025
+              </span>
             </li>
             <li className="mb-3 flex justify-between items-baseline gap-4">
               <Link href="/blog/i-worked-with-a-man-who-faked-his-own-death" className="flex-1">
                 I worked with a man who faked his own death
               </Link>
-              <span className="font-sans text-[0.82rem] text-[#888] shrink-0">Jun 2024</span>
+              <span className="font-sans text-[0.82rem] text-[#888] shrink-0">
+                {audioPosts['i-worked-with-a-man-who-faked-his-own-death'].src && <span className="audio-list-badge">Audio</span>}
+                Jun 2024
+              </span>
             </li>
             <li className="mb-3 flex justify-between items-baseline gap-4">
               <Link href="/blog/how-to-feel-when-your-startup-feels-easy" className="flex-1">
                 How to feel when your startup feels easy
               </Link>
-              <span className="font-sans text-[0.82rem] text-[#888] shrink-0">Mar 2024</span>
+              <span className="font-sans text-[0.82rem] text-[#888] shrink-0">
+                {audioPosts['how-to-feel-when-your-startup-feels-easy'].src && <span className="audio-list-badge">Audio</span>}
+                Mar 2024
+              </span>
             </li>
             <li className="mb-3 flex justify-between items-baseline gap-4">
               <Link href="/blog/surviving-five-years-in-the-most-dangerous-market" className="flex-1">
                 Thriving in the presence of risk — Crypto 2013–17
               </Link>
-              <span className="font-sans text-[0.82rem] text-[#888] shrink-0">Aug 2019</span>
+              <span className="font-sans text-[0.82rem] text-[#888] shrink-0">
+                {audioPosts['surviving-five-years-in-the-most-dangerous-market'].src && <span className="audio-list-badge">Audio</span>}
+                Aug 2019
+              </span>
             </li>
           </ul>
         </section>

--- a/docs/AUDIO_SETUP.md
+++ b/docs/AUDIO_SETUP.md
@@ -1,0 +1,35 @@
+# Adding an audio edition
+
+Audio is deliberately a static-file feature. It needs no account, database, podcast
+host, or subscription, and it continues to work with Next's static export.
+
+## Publish an MP3
+
+1. Record or generate a spoken version of the essay and export it as an MP3. Make
+   sure you have the rights and consent required for any cloned or synthetic voice.
+2. Keep the finished file reasonably small (64–96 kbps mono is usually sufficient
+   for speech), create `public/audio/` if needed, and copy the MP3 into it.
+3. Open `app/audio-posts.ts`, find the essay, and replace `src: null` with its public
+   path—for example:
+
+   ```ts
+   src: '/audio/how-to-feel-when-your-startup-feels-easy.mp3',
+   duration: '12 min',
+   ```
+
+4. Run `npm run build`. The post will now render an inline player plus Download,
+   Send / share, Copy link, and Email actions. The homepage will also mark that
+   essay as available in audio.
+5. Open the exported site over HTTPS and test the native share action on at least
+   one phone. Web Share support and available destinations vary by browser and
+   operating system; Download, Copy link, and Email remain available regardless.
+
+Do not configure `src` before the file exists. A `null` source intentionally renders
+an honest "being recorded" state and makes no media request.
+
+## About podcast apps
+
+This implementation distributes ordinary MP3 files and links. It does not claim
+that Apple Podcasts or Spotify can import arbitrary files. A future podcast-feed
+variant would require an RSS feed, stable public audio URLs, podcast artwork and
+metadata, plus separate submission and account setup with each directory.


### PR DESCRIPTION
## What changed

Adds a restrained “Take this essay with you” panel below the metadata on all four posts. Once a static MP3 is configured, it provides an inline player plus first-class Download, Send / share, Copy link, and Email-to-myself actions. The homepage introduces Listen later and marks only essays with published audio.

## Fallback behaviour

Native Web Share is progressive enhancement: supported devices can share the MP3 file or its URL; cancelled shares are quiet; unsupported or failed sharing falls back to copying the link. Download, copy, and email remain visible independently. Downloads are ordinary MP3s—this does not imply arbitrary files can be imported into Apple Podcasts or Spotify.

## Audio still needed

All four sources are intentionally `null`, so production renders an honest “being recorded” state and makes no broken media requests. To publish an edition, add the MP3 under `public/audio/`, set its `src` and duration in `app/audio-posts.ts`, and rebuild. Voice recording or generation is intentionally outside this PR; cloned or synthetic voice requires Gareth’s chosen provider and consent.

## Tradeoffs

This account-free static approach is simple and portable, but provides no podcast subscription/feed, hosting analytics, transcoding, or guaranteed native-share destinations. Web Share varies by HTTPS, browser, and OS, hence the explicit fallbacks.

## Validation

- `npm run build` passes; all routes statically exported
- Tested both a temporarily configured published source and the final all-unpublished state
- Confirmed the final export contains no `<audio>`, `<source>`, or `/audio/...` request while sources are null
- Compared branch against `main`: exactly 10 intended files, one commit ahead, zero behind
